### PR TITLE
Background app wake using remote config fetch and update

### DIFF
--- a/BT-Tracking/Supporting Files/Info.plist
+++ b/BT-Tracking/Supporting Files/Info.plist
@@ -61,6 +61,7 @@
 	<array>
 		<string>bluetooth-central</string>
 		<string>bluetooth-peripheral</string>
+		<string>fetch</string>
 		<string>remote-notification</string>
 	</array>
 	<key>UILaunchStoryboardName</key>


### PR DESCRIPTION
- added background fetch capability and the background fetching code in AppDelegate
- the fetch call used in background is Firebase remote config
- set minimum background fetch intervals, we might prolong it after initial testing