### PR TITLE
Fix success image references

### DIFF
--- a/BT-Tracking/Interface/Data List/DataList.storyboard
+++ b/BT-Tracking/Interface/Data List/DataList.storyboard
@@ -253,7 +253,7 @@
                                             <constraint firstAttribute="height" constant="5" id="AyS-cJ-DC6"/>
                                         </constraints>
                                     </view>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="ScanActiveIcon" translatesAutoresizingMaskIntoConstraints="NO" id="Xpr-3X-RXk">
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="ScanActive" translatesAutoresizingMaskIntoConstraints="NO" id="Xpr-3X-RXk">
                                         <rect key="frame" x="0.0" y="20" width="374" height="130"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="130" id="3cc-6O-U3A" customClass="LayoutConstraintHelper" customModule="eRouska" customModuleProvider="target">
@@ -414,7 +414,7 @@ Po smazání dat dojde k automatickému pozastavení eRoušky.</string>
         </scene>
     </scenes>
     <resources>
-        <image name="ScanActiveIcon" width="130" height="130"/>
+        <image name="ScanActive" width="48" height="48"/>
         <image name="Více informací" width="128" height="128"/>
         <image name="info.circle.fill" width="24" height="24"/>
     </resources>

--- a/BT-Tracking/Interface/Unregister User/UnregisterUser.storyboard
+++ b/BT-Tracking/Interface/Unregister User/UnregisterUser.storyboard
@@ -111,7 +111,7 @@ Zrušením registrace dojde k vypnutí aplikace ve všech zařízeních registro
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fjy-5T-lyh">
                                 <rect key="frame" x="16" y="365" width="382" height="166.5"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="scan.active" translatesAutoresizingMaskIntoConstraints="NO" id="vBp-M6-JBt">
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" image="ScanActive" translatesAutoresizingMaskIntoConstraints="NO" id="vBp-M6-JBt">
                                         <rect key="frame" x="0.0" y="0.0" width="382" height="130"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="130" id="6eK-l4-jTF" customClass="LayoutConstraintHelper" customModule="eRouska" customModuleProvider="target">
@@ -185,6 +185,6 @@ Zrušením registrace dojde k vypnutí aplikace ve všech zařízeních registro
         </scene>
     </scenes>
     <resources>
-        <image name="scan.active" width="48" height="48"/>
+        <image name="ScanActive" width="48" height="48"/>
     </resources>
 </document>


### PR DESCRIPTION
Due to a recent assets renaming, a couple of success images were not referenced correctly.