### PR TITLE
Add Swiftformat to enforce consistent Swift style

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,24 @@
+# file options
+
+--symlinks ignore
+--swiftversion 5.1
+
+# rules
+--enable isEmpty
+--disable andOperator
+
+# format options
+
+--closingparen same-line
+--commas inline
+--comments indent
+--decimalgrouping 3,5
+--exponentcase lowercase
+--exponentgrouping disabled
+--fractiongrouping disabled
+--ifdef no-indent
+--importgrouping testable-top
+--operatorfunc no-space
+--nospaceoperators ..<, ...
+--selfrequired validate
+--stripunusedargs closure-only

--- a/BT-Tracking/Extensions/Base/App.swift
+++ b/BT-Tracking/Extensions/Base/App.swift
@@ -10,10 +10,10 @@ import Foundation
 
 struct App {
     static var appVersion: String {
-        return Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
     }
 
     static var bundleBuild: String {
-        return Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? ""
     }
 }

--- a/BT-Tracking/Extensions/Base/Collection.swift
+++ b/BT-Tracking/Extensions/Base/Collection.swift
@@ -20,13 +20,13 @@ extension Collection where Element: BinaryInteger {
 
 extension Array where Element == Int {
     func median() -> Double? {
-        guard count > 0  else { return nil }
+        guard count > 0 else { return nil }
 
-        let sortedArray = self.sorted()
+        let sortedArray = sorted()
         if count % 2 != 0 {
-            return Double(sortedArray[count/2])
+            return Double(sortedArray[count / 2])
         } else {
-            return Double(sortedArray[count/2] + sortedArray[count/2 - 1]) / 2.0
+            return Double(sortedArray[count / 2] + sortedArray[count / 2 - 1]) / 2.0
         }
     }
 }

--- a/BT-Tracking/Extensions/Base/Data.swift
+++ b/BT-Tracking/Extensions/Base/Data.swift
@@ -10,7 +10,6 @@ import Foundation
 
 // https://stackoverflow.com/questions/39075043/how-to-convert-data-to-hex-string-in-swift
 extension Data {
-
     struct HexEncodingOptions: OptionSet {
         let rawValue: Int
         static let upperCase = HexEncodingOptions(rawValue: 1 << 0)
@@ -20,7 +19,6 @@ extension Data {
         let format = options.contains(.upperCase) ? "%02hhX" : "%02hhx"
         return map { String(format: format, $0) }.joined()
     }
-    
 }
 
 extension String {
@@ -28,12 +26,12 @@ extension String {
         // Convert 0 ... 9, a ... f, A ...F to their decimal value,
         // return nil for all other input characters
         func decodeNibble(u: UInt16) -> UInt8? {
-            switch(u) {
-            case 0x30 ... 0x39:
+            switch u {
+            case 0x30...0x39:
                 return UInt8(u - 0x30)
-            case 0x41 ... 0x46:
+            case 0x41...0x46:
                 return UInt8(u - 0x41 + 10)
-            case 0x61 ... 0x66:
+            case 0x61...0x66:
                 return UInt8(u - 0x61 + 10)
             default:
                 return nil

--- a/BT-Tracking/Extensions/Base/Image.swift
+++ b/BT-Tracking/Extensions/Base/Image.swift
@@ -9,18 +9,16 @@
 import UIKit
 
 extension UIImage {
-
     func resize(toWidth width: CGFloat) -> UIImage? {
-         let scale = width / size.width
-         let newHeight = size.height * scale
+        let scale = width / size.width
+        let newHeight = size.height * scale
 
-         UIGraphicsBeginImageContextWithOptions(CGSize(width: width, height: newHeight), false, UIScreen.main.scale)
-         draw(in: CGRect(x: 0, y: 0, width: width, height: newHeight))
+        UIGraphicsBeginImageContextWithOptions(CGSize(width: width, height: newHeight), false, UIScreen.main.scale)
+        draw(in: CGRect(x: 0, y: 0, width: width, height: newHeight))
 
-         let newImage = UIGraphicsGetImageFromCurrentImageContext()
-         UIGraphicsEndImageContext()
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
 
-         return newImage
-     }
-
+        return newImage
+    }
 }

--- a/BT-Tracking/Extensions/Base/Layout.swift
+++ b/BT-Tracking/Extensions/Base/Layout.swift
@@ -8,10 +8,11 @@
 
 import UIKit
 
-@IBDesignable class LayoutConstraintHelper : NSLayoutConstraint {
+@IBDesignable class LayoutConstraintHelper: NSLayoutConstraint {
     @IBInspectable var iP6AndSmaller: CGFloat = 0.0 {
         didSet { deviceConstant(0..<600, value: iP6AndSmaller) }
     }
+
     @IBInspectable var iP6PlusAndBigger: CGFloat = 0.0 {
         didSet { deviceConstant(600..<10_000, value: iP6PlusAndBigger) }
     }

--- a/BT-Tracking/Extensions/Base/String.swift
+++ b/BT-Tracking/Extensions/Base/String.swift
@@ -9,15 +9,14 @@
 import Foundation
 
 extension String {
-
     func chunkFormatted(withChunkSize chunkSize: Int = 4, withSeparator separator: Character = " ") -> String {
-        return filter { $0 != separator }
+        filter { $0 != separator }
             .chunk(n: chunkSize)
             .map { String($0) }
             .joined(separator: String(separator))
     }
 
     func removingSpaces() -> String {
-        return self.replacingOccurrences(of: " ", with: "")
+        replacingOccurrences(of: " ", with: "")
     }
 }

--- a/BT-Tracking/Extensions/Others/Auth.swift
+++ b/BT-Tracking/Extensions/Others/Auth.swift
@@ -9,17 +9,15 @@
 import FirebaseAuth
 
 extension Auth {
-
     static var isLoggedIn: Bool {
-        return KeychainService.BUID != nil && KeychainService.TUIDs != nil && Self.auth().currentUser != nil
+        KeychainService.BUID != nil && KeychainService.TUIDs != nil && Self.auth().currentUser != nil
     }
 }
 
 extension String {
-    
     var phoneFormatted: String {
-        let countryCode = self.dropLast(9)
-        let phone = String(self.suffix(9))
+        let countryCode = dropLast(9)
+        let phone = String(suffix(9))
         return countryCode + " " + phone.chunkFormatted(withChunkSize: 3)
     }
 }

--- a/BT-Tracking/Extensions/Others/InputValidation.swift
+++ b/BT-Tracking/Extensions/Others/InputValidation.swift
@@ -51,7 +51,6 @@ enum InputValidation {
 }
 
 extension UITextFieldDelegate {
-
     func validateTextChange(with type: InputValidation, textField: UITextField, changeCharactersIn range: NSRange, newString string: String) -> Bool {
         guard let text = textField.text else { return true }
 
@@ -66,5 +65,4 @@ extension UITextFieldDelegate {
         }
         return false
     }
-
 }

--- a/BT-Tracking/Extensions/Others/MulticastDelegate.swift
+++ b/BT-Tracking/Extensions/Others/MulticastDelegate.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 // https://stackoverflow.com/questions/41552754/swift-create-a-multi-function-multicast-delegate
-class MulticastDelegate <T>: NSObject {
+class MulticastDelegate<T>: NSObject {
     internal let delegates: NSHashTable<AnyObject> = NSHashTable.weakObjects()
 
     func add(delegate: T) {
@@ -23,10 +23,10 @@ class MulticastDelegate <T>: NSObject {
     }
 }
 
-func += <T: AnyObject> (left: MulticastDelegate<T>, right: T) {
+func += <T: AnyObject>(left: MulticastDelegate<T>, right: T) {
     left.add(delegate: right)
 }
 
-func -= <T: AnyObject> (left: MulticastDelegate<T>, right: T) {
+func -= <T: AnyObject>(left: MulticastDelegate<T>, right: T) {
     left.remove(delegate: right)
 }

--- a/BT-Tracking/Extensions/UIKit/Button.swift
+++ b/BT-Tracking/Extensions/UIKit/Button.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 class Button: UIButton {
-
     enum Style {
         case filled
         case clear
@@ -98,29 +97,24 @@ class Button: UIButton {
 
         layer.borderColor = borderColor?.cgColor
     }
-
 }
 
-final class RoundedButtonFilled: Button {
-
-}
+final class RoundedButtonFilled: Button {}
 
 final class MainScanningButton: Button {
-    
     override func awakeFromNib() {
         super.awakeFromNib()
-        
+
         if #available(iOS 13.0, *) {
             backgroundColor = UIColor.systemGray6
         } else {
-            backgroundColor = UIColor(red: 237/255.0, green: 238/255.0, blue: 240/255.0, alpha: 1)
+            backgroundColor = UIColor(red: 237 / 255.0, green: 238 / 255.0, blue: 240 / 255.0, alpha: 1)
         }
         setTitleColor(.systemBlue, for: .normal)
     }
 }
 
 final class RoundedButtonClear: Button {
-
     override func awakeFromNib() {
         style = .clear
         super.awakeFromNib()

--- a/BT-Tracking/Extensions/UIKit/ButtonsBackgroundView.swift
+++ b/BT-Tracking/Extensions/UIKit/ButtonsBackgroundView.swift
@@ -6,11 +6,10 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import UIKit
 import RxSwift
+import UIKit
 
 class ButtonsBackgroundView: UIView {
-
     static var TopOffset: CGFloat = -44
 
     static var BottomMargin: CGFloat = 16
@@ -41,7 +40,7 @@ class ButtonsBackgroundView: UIView {
     private func setup() {
         backgroundColor = .clear
         clipsToBounds = false
-        
+
         let gradientView = GradientView()
         gradientView.translatesAutoresizingMaskIntoConstraints = false
         gradientView.isUserInteractionEnabled = false
@@ -85,5 +84,4 @@ class ButtonsBackgroundView: UIView {
             self.isGradientHidden = hideGradient
         }).disposed(by: disposeBag)
     }
-
 }

--- a/BT-Tracking/Extensions/UIKit/Controller.swift
+++ b/BT-Tracking/Extensions/UIKit/Controller.swift
@@ -6,11 +6,10 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import UIKit
 import SafariServices
+import UIKit
 
 extension UIViewController {
-
     func show(error: Error, title: String = "Chyba") {
         showError(title: title, message: error.localizedDescription)
     }
@@ -19,10 +18,9 @@ extension UIViewController {
         let alertController = UIAlertController(
             title: title,
             message: message,
-            preferredStyle: .alert
-        )
+            preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: okTitle, style: .cancel, handler: { _ in okHandler?() }))
-        action.flatMap({ action in alertController.addAction(UIAlertAction(title: action.title, style: .default, handler: { _ in action.handler?() })) })
+        action.flatMap { action in alertController.addAction(UIAlertAction(title: action.title, style: .default, handler: { _ in action.handler?() })) }
         present(alertController, animated: true)
     }
 
@@ -30,5 +28,4 @@ extension UIViewController {
         let controller = SFSafariViewController(url: URL)
         present(controller, animated: true, completion: nil)
     }
-
 }

--- a/BT-Tracking/Extensions/UIKit/GradientView.swift
+++ b/BT-Tracking/Extensions/UIKit/GradientView.swift
@@ -6,11 +6,10 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import UIKit
 import QuartzCore
+import UIKit
 
 class GradientView: UIView {
-
     private weak var gradientMaskLayer: CAGradientLayer!
 
     override init(frame: CGRect = .zero) {
@@ -27,7 +26,7 @@ class GradientView: UIView {
 
     private func setup() {
         let layer = CAGradientLayer()
-        self.gradientMaskLayer = layer
+        gradientMaskLayer = layer
         layer.frame = bounds
         self.layer.mask = layer
         layer.startPoint = CGPoint(x: 0, y: 0)
@@ -45,5 +44,4 @@ class GradientView: UIView {
 
         gradientMaskLayer.frame = bounds
     }
-
 }

--- a/BT-Tracking/Extensions/UIKit/KeyboardHandler.swift
+++ b/BT-Tracking/Extensions/UIKit/KeyboardHandler.swift
@@ -6,12 +6,11 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import UIKit
-import RxSwift
 import RxKeyboard
+import RxSwift
+import UIKit
 
 struct KeyboardHandler {
-
     let view: UIView
     let scrollView: UIScrollView
     let buttonsView: ButtonsBackgroundView
@@ -50,9 +49,8 @@ struct KeyboardHandler {
                 let height = (self.scrollView.frame.height - adjustedHeight)
                 let contentSize = self.scrollView.contentSize
                 guard contentSize.height - height > -60 else { return }
-                self.scrollView.scrollRectToVisible(CGRect(x: 0, y: (contentSize.height - height), width: contentSize.width, height: height), animated: true)
+                self.scrollView.scrollRectToVisible(CGRect(x: 0, y: contentSize.height - height, width: contentSize.width, height: height), animated: true)
             }
         }, completion: nil)
     }
-
 }

--- a/BT-Tracking/Extensions/UIKit/NavigationController.swift
+++ b/BT-Tracking/Extensions/UIKit/NavigationController.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 class NavigationController: UINavigationController {
-
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         if UIDevice.current.userInterfaceIdiom == .pad {
             return .all
@@ -17,5 +16,4 @@ class NavigationController: UINavigationController {
             return .portrait
         }
     }
-
 }

--- a/BT-Tracking/Extensions/UIKit/TabBarController.swift
+++ b/BT-Tracking/Extensions/UIKit/TabBarController.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 class TabBarController: UITabBarController {
-
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         if UIDevice.current.userInterfaceIdiom == .pad {
             return .all
@@ -17,5 +16,4 @@ class TabBarController: UITabBarController {
             return .portrait
         }
     }
-
 }

--- a/BT-Tracking/Interface/Active/ActiveAppController.swift
+++ b/BT-Tracking/Interface/Active/ActiveAppController.swift
@@ -6,29 +6,28 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import UIKit
-import FirebaseAuth
 import CoreBluetooth
+import FirebaseAuth
+import UIKit
 
 final class ActiveAppController: UIViewController {
-
     private var viewModel = ActiveAppViewModel(bluetoothActive: true)
-    
+
     // MARK: - Outlets
 
-    @IBOutlet private weak var mainStackView: UIStackView!
-    @IBOutlet private weak var imageView: UIImageView!
-    @IBOutlet private weak var headLabel: UILabel!
-    @IBOutlet private weak var titleLabel: UILabel!
-    @IBOutlet private weak var tipsLabel: UILabel!
-    @IBOutlet private weak var firstTipLabel: UILabel!
-    @IBOutlet private weak var secondTipLabel: UILabel!
-    @IBOutlet private weak var textLabel: UILabel!
+    @IBOutlet private var mainStackView: UIStackView!
+    @IBOutlet private var imageView: UIImageView!
+    @IBOutlet private var headLabel: UILabel!
+    @IBOutlet private var titleLabel: UILabel!
+    @IBOutlet private var tipsLabel: UILabel!
+    @IBOutlet private var firstTipLabel: UILabel!
+    @IBOutlet private var secondTipLabel: UILabel!
+    @IBOutlet private var textLabel: UILabel!
     @IBOutlet private var activeInfoViews: [UIView]!
-    @IBOutlet private weak var actionButton: Button! 
-    @IBOutlet private weak var cardView: UIView!
-    @IBOutlet private weak var actionButtonWidthConstraint: NSLayoutConstraint!
-    
+    @IBOutlet private var actionButton: Button!
+    @IBOutlet private var cardView: UIView!
+    @IBOutlet private var actionButtonWidthConstraint: NSLayoutConstraint!
+
     // MARK: -
 
     override func viewDidLoad() {
@@ -50,7 +49,7 @@ final class ActiveAppController: UIViewController {
         updateScanner()
         updateInterface()
     }
-    
+
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
 
@@ -66,26 +65,24 @@ final class ActiveAppController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        
+
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(applicationDidBecomeActive),
             name: UIApplication.didBecomeActiveNotification,
-            object: nil
-        )
+            object: nil)
 
         checkForBluetooth()
         checkBackgroundModeIfNeeded()
     }
-    
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        
+
         NotificationCenter.default.removeObserver(
             self,
             name: UIApplication.didBecomeActiveNotification,
-            object: nil
-        )
+            object: nil)
     }
 
     // MARK: - Actions
@@ -110,7 +107,7 @@ final class ActiveAppController: UIViewController {
         let shareContent: [Any] = [message]
         let activityViewController = UIActivityViewController(activityItems: shareContent, applicationActivities: nil)
         activityViewController.popoverPresentationController?.barButtonItem = navigationItem.rightBarButtonItems?.last ?? navigationItem.rightBarButtonItem
-        
+
         present(activityViewController, animated: true, completion: nil)
     }
 
@@ -152,15 +149,13 @@ final class ActiveAppController: UIViewController {
     }
 
     // MARK: -
-    
+
     @objc private func applicationDidBecomeActive() {
         checkForBluetooth()
     }
-
 }
 
 private extension ActiveAppController {
-
     func updateViewModel() {
         viewModel = ActiveAppViewModel(bluetoothActive: viewModel.lastBluetoothState)
 
@@ -238,8 +233,7 @@ private extension ActiveAppController {
         let controller = UIAlertController(
             title: "Aktualizace na pozadí",
             message: "eRouška se potřebuje sama spustit i na pozadí, například po restartování telefonu, abyste na to nemuseli myslet vy.\n\nPovolte možnost 'Aktualizace na pozadí' v nastavení aplikace.",
-            preferredStyle: .alert
-        )
+            preferredStyle: .alert)
         controller.addAction(UIAlertAction(title: "Upravit nastavení", style: .default, handler: { [weak self] _ in
             self?.openSettings()
         }))
@@ -247,7 +241,7 @@ private extension ActiveAppController {
         controller.preferredAction = controller.actions.first
         present(controller, animated: true)
     }
-    
+
     func openSettings() {
         guard let settingsUrl = URL(string: UIApplication.openSettingsURLString), UIApplication.shared.canOpenURL(settingsUrl) else { return }
         UIApplication.shared.open(settingsUrl)
@@ -264,5 +258,4 @@ private extension ActiveAppController {
         guard let URL = url else { return }
         UIApplication.shared.open(URL)
     }
-
 }

--- a/BT-Tracking/Interface/Active/ActiveAppViewModel.swift
+++ b/BT-Tracking/Interface/Active/ActiveAppViewModel.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 final class ActiveAppViewModel {
-
     enum State: String {
         case enabled
         case paused
@@ -75,17 +74,17 @@ final class ActiveAppViewModel {
                 return "Bez zapnutého Bluetooth nemůžeme vytvářet seznam telefonů ve vašem okolí.\n\nZapněte jej pomocí tlačítka \"Zapnout\"."
             }
         }
-        
+
         var tips: String {
-            return "Tipy pro snížení spotřeby baterie"
+            "Tipy pro snížení spotřeby baterie"
         }
-        
+
         var firstTip: String {
-            return "Na stole otočte telefon obrazovkou dolů. Obrazovka automaticky zhasne."
+            "Na stole otočte telefon obrazovkou dolů. Obrazovka automaticky zhasne."
         }
-        
+
         var secondTip: String {
-            return "Do kapsy dávejte telefon nabíjecím konektorem nahoru. Zakrytá obrazovka automaticky zhasne."
+            "Do kapsy dávejte telefon nabíjecím konektorem nahoru. Zakrytá obrazovka automaticky zhasne."
         }
 
         var text: String {
@@ -135,7 +134,7 @@ final class ActiveAppViewModel {
     var lastBluetoothState: Bool // true enabled
 
     init(bluetoothActive: Bool) {
-        self.lastBluetoothState = bluetoothActive
+        lastBluetoothState = bluetoothActive
 
         if !bluetoothActive {
             state = .disabled

--- a/BT-Tracking/Interface/Active/ContactsController.swift
+++ b/BT-Tracking/Interface/Active/ContactsController.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 final class ContactsController: UIViewController {
-
     override func awakeFromNib() {
         super.awakeFromNib()
 
@@ -51,5 +50,4 @@ final class ContactsController: UIViewController {
             navigationController?.tabBarItem.image = UIImage(named: "phone")?.resize(toWidth: 26)
         }
     }
-
 }

--- a/BT-Tracking/Interface/Active/SendReportController.swift
+++ b/BT-Tracking/Interface/Active/SendReportController.swift
@@ -9,9 +9,7 @@
 import UIKit
 
 final class SendReportController: UIViewController {
-
     @IBAction private func closeAction() {
         dismiss(animated: true, completion: nil)
     }
-
 }

--- a/BT-Tracking/Interface/Data List/Cells/DataCell.swift
+++ b/BT-Tracking/Interface/Data List/Cells/DataCell.swift
@@ -9,13 +9,12 @@
 import UIKit
 
 final class DataCell: UITableViewCell {
-
     static let identifier = "dataCell"
 
-    @IBOutlet private weak var buidLabel: UILabel!
-    @IBOutlet private weak var dateLabel: UILabel!
-    @IBOutlet private weak var timeLabel: UILabel!
-    @IBOutlet private weak var RSSILabel: UILabel!
+    @IBOutlet private var buidLabel: UILabel!
+    @IBOutlet private var dateLabel: UILabel!
+    @IBOutlet private var timeLabel: UILabel!
+    @IBOutlet private var RSSILabel: UILabel!
 
     func configure(for scan: Scan) {
         buidLabel.text = String(scan.buid.prefix(6)) + "..."

--- a/BT-Tracking/Interface/Data List/Cells/DataHeaderCell.swift
+++ b/BT-Tracking/Interface/Data List/Cells/DataHeaderCell.swift
@@ -9,10 +9,9 @@
 import UIKit
 
 final class DataHeaderCell: UITableViewCell {
-
     static let identifier = "headerCell"
 
-    @IBOutlet private weak var segmentedControl: UISegmentedControl!
+    @IBOutlet private var segmentedControl: UISegmentedControl!
 
     func configure(with numberOfScans: Int) {
         segmentedControl.setTitle("Vše", forSegmentAt: 0)

--- a/BT-Tracking/Interface/Data List/DataCollectionInfoVC.swift
+++ b/BT-Tracking/Interface/Data List/DataCollectionInfoVC.swift
@@ -6,15 +6,16 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import UIKit
 import MarkdownKit
+import UIKit
 
 final class DataCollectionInfoVC: UIViewController {
-
     // MARK: Private Properties
+
     private let textView = UITextView()
 
     // MARK: Lifecycle
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -40,8 +41,7 @@ final class DataCollectionInfoVC: UIViewController {
             top: 16,
             left: view.layoutMargins.left,
             bottom: 16,
-            right: view.layoutMargins.right
-        )
+            right: view.layoutMargins.right)
     }
 
     private func layoutViews() {
@@ -52,7 +52,7 @@ final class DataCollectionInfoVC: UIViewController {
             textView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             textView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             textView.topAnchor.constraint(equalTo: view.topAnchor),
-            textView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            textView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
 

--- a/BT-Tracking/Interface/Data List/DeleteDataVC.swift
+++ b/BT-Tracking/Interface/Data List/DeleteDataVC.swift
@@ -9,25 +9,24 @@
 import UIKit
 
 final class DeleteDataVC: UIViewController {
-
     private let viewModel = DeleteDataVM(scannerStore: AppDelegate.shared.scannerStore)
 
     // MARK: - Life cycle
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
         setup()
     }
-    
+
     // MARK: - Setup
-    
+
     private func setup() {
         title = "Smazat data"
         navigationController?.navigationBar.prefersLargeTitles = true
     }
-    
+
     // MARK: - Action
-    
+
     @IBAction private func deleteAllData(_ sender: Any) {
         viewModel.deleteAllData()
 

--- a/BT-Tracking/Interface/Data List/DeleteDataVM.swift
+++ b/BT-Tracking/Interface/Data List/DeleteDataVM.swift
@@ -9,25 +9,22 @@
 import Foundation
 
 final class DeleteDataVM {
-    
     // MARK: - Properties
-    
+
     private let scannerStore: ScannerStore
-    
+
     // MARK: - Init
-    
+
     init(scannerStore: ScannerStore) {
         self.scannerStore = scannerStore
     }
-    
+
     // MARK: - Alert
-    
-    func showAlert() {
-        
-    }
-    
+
+    func showAlert() {}
+
     // MARK: - Delete data
-    
+
     func deleteAllData() {
         scannerStore.deleteAllData()
         FileLogger.shared.purgeLogs()

--- a/BT-Tracking/Interface/Debug/Cells/InfoCell.swift
+++ b/BT-Tracking/Interface/Debug/Cells/InfoCell.swift
@@ -9,17 +9,15 @@
 import UIKit
 
 final class InfoCell: UITableViewCell {
-
     static let identifier = "infoCell"
 
-    @IBOutlet private weak var buidLabel: UILabel!
-    @IBOutlet private weak var tuidLabel: UILabel!
-    @IBOutlet private weak var infoLabel: UILabel!
+    @IBOutlet private var buidLabel: UILabel!
+    @IBOutlet private var tuidLabel: UILabel!
+    @IBOutlet private var infoLabel: UILabel!
 
     func configure(for buid: String?, tuid: String?) {
         buidLabel.text = buid ?? "nepřidělen"
         tuidLabel.text = tuid ?? "nepřidělen"
         infoLabel.text = "Verze \(App.appVersion)(\(App.bundleBuild))"
     }
-
 }

--- a/BT-Tracking/Interface/Debug/Cells/ScanCell.swift
+++ b/BT-Tracking/Interface/Debug/Cells/ScanCell.swift
@@ -9,26 +9,24 @@
 import UIKit
 
 final class ScanCell: UITableViewCell {
-
     static let identifier = "scanCell"
 
-    @IBOutlet private weak var nameLabel: UILabel!
-    @IBOutlet private weak var identifierLabel: UILabel!
-    @IBOutlet private weak var dateLabel: UILabel!
-    @IBOutlet private weak var rssiLabel: UILabel!
+    @IBOutlet private var nameLabel: UILabel!
+    @IBOutlet private var identifierLabel: UILabel!
+    @IBOutlet private var dateLabel: UILabel!
+    @IBOutlet private var rssiLabel: UILabel!
 
     func configure(for scan: Scan) {
         nameLabel.text = scan.name == scan.platform.rawValue ? scan.name : scan.platform.rawValue + " - " + scan.name
         identifierLabel.text = "BT: " + scan.bluetoothIdentifier
         dateLabel.text = ScanCell.formatter.string(from: scan.date)
-        rssiLabel.text = String(scan.rssi)  + " dB, TUID: " + scan.buid
+        rssiLabel.text = String(scan.rssi) + " dB, TUID: " + scan.buid
     }
-    
+
     private static var formatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .short
         formatter.timeStyle = .medium
         return formatter
     }()
-
 }

--- a/BT-Tracking/Interface/Debug/Cells/SectionTitleCell.swift
+++ b/BT-Tracking/Interface/Debug/Cells/SectionTitleCell.swift
@@ -9,11 +9,10 @@
 import UIKit
 
 final class SectionTitleCell: UITableViewCell {
-
     static let identifier = "sectionTitleCell"
 
-    @IBOutlet weak var titleLabel: UILabel!
-    
+    @IBOutlet var titleLabel: UILabel!
+
     func configure(for title: String) {
         titleLabel.text = title
     }

--- a/BT-Tracking/Interface/Debug/Log List/FileLogController.swift
+++ b/BT-Tracking/Interface/Debug/Log List/FileLogController.swift
@@ -9,10 +9,9 @@
 import UIKit
 
 final class FileLogController: UIViewController {
-
     // MARK: - Outlets
 
-    @IBOutlet private weak var textView: UITextView!
+    @IBOutlet private var textView: UITextView!
 
     private var timer: Timer?
 
@@ -39,7 +38,7 @@ final class FileLogController: UIViewController {
     private func setup() {
         textView.text = ""
 
-        timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] timer in
+        timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
             self?.textView.text = FileLogger.shared.getLog()
         }
     }
@@ -49,5 +48,4 @@ final class FileLogController: UIViewController {
     func purgeLog() {
         textView.text = ""
     }
-    
 }

--- a/BT-Tracking/Interface/Debug/Log List/LogController.swift
+++ b/BT-Tracking/Interface/Debug/Log List/LogController.swift
@@ -6,15 +6,14 @@
 //  Copyright © 2020 hatchery41. All rights reserved.
 //
 
-import UIKit
 import CoreBluetooth
+import UIKit
 
 final class LogController: UIViewController {
-    
     // MARK: - Outlets
-    
-    @IBOutlet weak var textView: UITextView!
-    
+
+    @IBOutlet var textView: UITextView!
+
     // MARK: - Properties
 
     private let scanner: BTScannering = AppDelegate.shared.scanner
@@ -35,9 +34,9 @@ final class LogController: UIViewController {
         super.viewDidLoad()
         setup()
     }
-    
+
     // MARK: - Setup
-    
+
     private func setup() {
         Log.delegate = self
 
@@ -51,7 +50,6 @@ final class LogController: UIViewController {
     func purgeLog() {
         logText = ""
     }
-
 }
 
 extension LogController: BTScannerDelegate {
@@ -80,9 +78,8 @@ extension LogController: BTScannerDelegate {
         guard AppDelegate.inBackground, let notification = notification else { return }
         notification.sound = .none
 
-        let request = UNNotificationRequest(identifier: "Scanning",  content: notification, trigger: nil)
+        let request = UNNotificationRequest(identifier: "Scanning", content: notification, trigger: nil)
         UNUserNotificationCenter.current().add(request)
-
     }
 }
 

--- a/BT-Tracking/Interface/Debug/Log List/LogSegmentController.swift
+++ b/BT-Tracking/Interface/Debug/Log List/LogSegmentController.swift
@@ -9,11 +9,10 @@
 import UIKit
 
 final class LogSegmentController: UIViewController {
+    @IBOutlet private var segmentControl: UISegmentedControl!
 
-    @IBOutlet private weak var segmentControl: UISegmentedControl!
-
-    @IBOutlet private weak var leftContainerView: UIView!
-    @IBOutlet private weak var rightContainerView: UIView!
+    @IBOutlet private var leftContainerView: UIView!
+    @IBOutlet private var rightContainerView: UIView!
 
     private weak var leftController: LogController!
     private weak var rightController: FileLogController!
@@ -28,7 +27,7 @@ final class LogSegmentController: UIViewController {
         } else {
             navigationController?.tabBarItem.image = UIImage(named: "doc.plaintext")?.resize(toWidth: 20)
         }
-        
+
         navigationItem.largeTitleDisplayMode = .never
     }
 
@@ -78,5 +77,4 @@ final class LogSegmentController: UIViewController {
         leftController.purgeLog()
         rightController.purgeLog()
     }
-
 }

--- a/BT-Tracking/Interface/Debug/Scan List/ScanListVC.swift
+++ b/BT-Tracking/Interface/Debug/Scan List/ScanListVC.swift
@@ -6,21 +6,20 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import RxSwift
+import FirebaseAuth
 import RxCocoa
 import RxDataSources
-import FirebaseAuth
+import RxSwift
 
 final class ScanListVC: UIViewController, UITableViewDelegate {
-
-    @IBOutlet private weak var tableView: UITableView!
+    @IBOutlet private var tableView: UITableView!
 
     private var dataSource: RxTableViewSectionedAnimatedDataSource<ScanListVM.SectionModel>!
     private var viewModel = ScanListVM(scannerStore: AppDelegate.shared.scannerStore)
     private let bag = DisposeBag()
 
     // MARK: - Lifecycle
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -48,7 +47,7 @@ final class ScanListVC: UIViewController, UITableViewDelegate {
             AppDelegate.shared.advertiser.stop()
             AppDelegate.shared.scanner.stop()
             AppDelegate.shared.scannerStore.deleteAllData()
-            
+
             AppSettings.deleteAllData()
 
             try Auth.auth().signOut()
@@ -61,53 +60,50 @@ final class ScanListVC: UIViewController, UITableViewDelegate {
         }
     }
 
-
     @IBAction func clearAction(_ sender: Any) {
         viewModel.clear()
     }
-
 
     @IBAction func closeAction(_ sender: Any) {
         dismiss(animated: true, completion: nil)
     }
 
-
     // MARK: - TableView
-    
+
     private func setupTableView() {
         tableView.tableFooterView = UIView()
         tableView.allowsSelection = false
         tableView.rowHeight = UITableView.automaticDimension
 
-        dataSource = RxTableViewSectionedAnimatedDataSource<ScanListVM.SectionModel>(configureCell: { datasource, tableView, indexPath, row in
+        dataSource = RxTableViewSectionedAnimatedDataSource<ScanListVM.SectionModel>(configureCell: { _, tableView, indexPath, row in
             let cell: UITableViewCell?
             switch row {
-            case .info(let buid):
+            case let .info(buid):
                 let infoCell = tableView.dequeueReusableCell(withIdentifier: InfoCell.identifier, for: indexPath) as? InfoCell
                 infoCell?.configure(for: buid, tuid: AppDelegate.shared.advertiser.currentID)
                 cell = infoCell
-            case .scan(let scan):
+            case let .scan(scan):
                 let scanCell = tableView.dequeueReusableCell(withIdentifier: ScanCell.identifier, for: indexPath) as? ScanCell
                 scanCell?.configure(for: scan)
                 cell = scanCell
             }
             return cell ?? UITableViewCell()
         })
-        
+
         viewModel.sections
             .drive(tableView.rx.items(dataSource: dataSource))
             .disposed(by: bag)
-        
+
         tableView.rx.setDelegate(self)
             .disposed(by: bag)
-        
+
         dataSource.animationConfiguration = AnimationConfiguration(insertAnimation: .fade, reloadAnimation: .none, deleteAnimation: .fade)
     }
-    
+
     // MARK: - TableView section header
-    
+
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 29
+        29
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -116,5 +112,4 @@ final class ScanListVC: UIViewController, UITableViewDelegate {
         cell?.configure(for: datasourceSection.model.identity)
         return cell?.contentView ?? UIView()
     }
-
 }

--- a/BT-Tracking/Interface/Debug/Scan List/ScanListVM.swift
+++ b/BT-Tracking/Interface/Debug/Scan List/ScanListVM.swift
@@ -6,53 +6,51 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import RxSwift
 import RxCocoa
 import RxDataSources
+import RxSwift
 
 final class ScanListVM {
-    
     // MARK: - Properties
-    
+
     private let scannerStore: ScannerStore
-    
+
     // MARK: - Init
-    
+
     init(scannerStore: ScannerStore) {
         self.scannerStore = scannerStore
     }
-    
+
     // MARK: - Sections
-    
+
     var sections: Driver<[SectionModel]> {
         let infoSection = SectionModel(
             model: .info,
-            items: [Section.Item.info(KeychainService.BUID)]
-        )
+            items: [Section.Item.info(KeychainService.BUID)])
 
         let current = scannerStore.currentScan
             .map { unsortedScans in
-                return unsortedScans.sorted(by: { scan0, scan1 in scan0.buid < scan1.buid })
+                unsortedScans.sorted(by: { scan0, scan1 in scan0.buid < scan1.buid })
             }
             .map { [unowned self] scans -> [SectionModel] in
-                return self.section(from: scans, for: .current)
+                self.section(from: scans, for: .current)
             }
         let log = scannerStore.scans
             .map { unsortedScans in
-                return unsortedScans.sorted(by: { scan0, scan1 in scan0.date > scan1.date })
+                unsortedScans.sorted(by: { scan0, scan1 in scan0.date > scan1.date })
             }
             .map { [unowned self] scans -> [SectionModel] in
-                return self.section(from: scans, for: .log)
+                self.section(from: scans, for: .log)
             }
 
         return Observable.combineLatest(current.startWith([]), log.startWith([])) { currentSection, logSection -> [SectionModel] in
-            return [infoSection] + currentSection + logSection
+            [infoSection] + currentSection + logSection
         }
         .asDriver(onErrorJustReturn: [])
     }
-    
+
     // MARK: - Clear stored records
-    
+
     func clear() {
         scannerStore.deleteAllData()
     }
@@ -61,7 +59,6 @@ final class ScanListVM {
 // MARK: - Sections helpers
 
 extension ScanListVM {
-
     private func section(from scans: [Scan], for section: Section) -> [SectionModel] {
         let items: [ScanListVM.Section.Item] = scans.map { .scan($0) }
         return [
@@ -73,14 +70,13 @@ extension ScanListVM {
 // MARK: - Sections
 
 extension ScanListVM {
-    
     typealias SectionModel = AnimatableSectionModel<Section, Section.Item>
 
     enum Section: IdentifiableType, Equatable {
         case info
         case current
         case log
-        
+
         var identity: String {
             switch self {
             case .info:
@@ -91,11 +87,11 @@ extension ScanListVM {
                 return "History"
             }
         }
-        
-        static func == (lhs: Section, rhs: Section) -> Bool {
-            return lhs.identity == rhs.identity
+
+        static func ==(lhs: Section, rhs: Section) -> Bool {
+            lhs.identity == rhs.identity
         }
-        
+
         enum Item: IdentifiableType, Equatable {
             case info(_ buid: String?)
             case scan(Scan)
@@ -104,7 +100,7 @@ extension ScanListVM {
                 switch self {
                 case .info:
                     return "buid"
-                case .scan(let scan):
+                case let .scan(scan):
                     return scan.id
                 }
             }
@@ -113,7 +109,7 @@ extension ScanListVM {
                 switch self {
                 case .info:
                     return "buid"
-                case .scan(let scan):
+                case let .scan(scan):
                     return scan
                 }
             }
@@ -122,12 +118,12 @@ extension ScanListVM {
                 switch self {
                 case .info:
                     return nil
-                case .scan(let scan):
+                case let .scan(scan):
                     return scan.rssi
                 }
             }
-            
-            static func == (lhs: Item, rhs: Item) -> Bool {
+
+            static func ==(lhs: Item, rhs: Item) -> Bool {
                 if let l = lhs.object as? Scan, let r = rhs.object as? Scan {
                     return l == r
                 } else {

--- a/BT-Tracking/Interface/Help/HelpVC.swift
+++ b/BT-Tracking/Interface/Help/HelpVC.swift
@@ -6,13 +6,12 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import RxSwift
-import RxCocoa
 import MarkdownKit
+import RxCocoa
+import RxSwift
 
 final class HelpVC: UIViewController {
-
-    @IBOutlet private weak var textView: UITextView!
+    @IBOutlet private var textView: UITextView!
 
     private let bag = DisposeBag()
 
@@ -35,8 +34,7 @@ final class HelpVC: UIViewController {
             top: 16,
             left: view.layoutMargins.left,
             bottom: 16,
-            right: view.layoutMargins.right
-        )
+            right: view.layoutMargins.right)
     }
 
     // MARK: - Actions

--- a/BT-Tracking/Interface/Signup/AccountActivationController.swift
+++ b/BT-Tracking/Interface/Signup/AccountActivationController.swift
@@ -6,14 +6,13 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import UIKit
-import RxSwift
-import RxRelay
-import FirebaseAuth
 import DeviceKit
+import FirebaseAuth
+import RxRelay
+import RxSwift
+import UIKit
 
 final class AccountActivationController: UIViewController {
-
     struct AuthData {
         let verificationID: String
         let phoneNumber: String
@@ -23,21 +22,22 @@ final class AccountActivationController: UIViewController {
     private var phoneNumber = BehaviorRelay<String>(value: "")
     private var isValid: Observable<Bool> {
         Observable.combineLatest(phonePrefix.asObservable(), phoneNumber.asObservable()).map { (phonePrefix, phoneNumber) -> Bool in
-            return InputValidation.prefix.validate(phonePrefix) && InputValidation.number.validate(phoneNumber)
+            InputValidation.prefix.validate(phonePrefix) && InputValidation.number.validate(phoneNumber)
         }
     }
+
     private var keyboardHandler: KeyboardHandler!
     private var disposeBag = DisposeBag()
 
-    @IBOutlet private weak var scrollView: UIScrollView!
-    @IBOutlet private weak var buttonsView: ButtonsBackgroundView!
-    @IBOutlet private weak var buttonsBottomConstraint: NSLayoutConstraint!
+    @IBOutlet private var scrollView: UIScrollView!
+    @IBOutlet private var buttonsView: ButtonsBackgroundView!
+    @IBOutlet private var buttonsBottomConstraint: NSLayoutConstraint!
 
-    @IBOutlet private weak var phonePrefixTextField: UITextField!
-    @IBOutlet private weak var phoneNumberTextField: UITextField!
-    @IBOutlet private weak var actionButton: UIButton!
-    @IBOutlet private weak var permissionSwitch: UISwitch!
-    @IBOutlet private weak var activityView: UIView!
+    @IBOutlet private var phonePrefixTextField: UITextField!
+    @IBOutlet private var phoneNumberTextField: UITextField!
+    @IBOutlet private var actionButton: UIButton!
+    @IBOutlet private var permissionSwitch: UISwitch!
+    @IBOutlet private var activityView: UIView!
 
     private var firstAppear: Bool = true
 
@@ -48,7 +48,7 @@ final class AccountActivationController: UIViewController {
 
         buttonsView.connect(with: scrollView)
         buttonsBottomConstraint.constant = ButtonsBackgroundView.BottomMargin
-        
+
         phonePrefixTextField.rx.text.orEmpty.bind(to: phonePrefix).disposed(by: disposeBag)
         phoneNumberTextField.rx.text.orEmpty.bind(to: phoneNumber).disposed(by: disposeBag)
 
@@ -84,10 +84,9 @@ final class AccountActivationController: UIViewController {
 
     @IBAction private func activateAcountAction() {
         guard permissionSwitch.isOn else {
-            self.showError(
+            showError(
                 title: "Souhlas s podmínkami zpracování je nezbytný pro aktivaci aplikace. Bez vašeho souhlasu nemůže aplikace fungovat.",
-                message: ""
-            )
+                message: "")
             return
         }
 
@@ -107,7 +106,7 @@ final class AccountActivationController: UIViewController {
                     self.showError(title: "Nepodařilo se nám ověřit telefonní číslo", message: "Zkontrolujte připojení k internetu a zkuste to znovu")
                 }
                 self.cleanup()
-            } else if let verificationID = verificationID  {
+            } else if let verificationID = verificationID {
                 self.performSegue(withIdentifier: "verification", sender: AuthData(verificationID: verificationID, phoneNumber: phone))
             }
         }
@@ -117,11 +116,9 @@ final class AccountActivationController: UIViewController {
         guard let url = URL(string: RemoteValues.termsAndConditionsLink) else { return }
         openURL(URL: url)
     }
-
 }
 
 extension AccountActivationController: UITextFieldDelegate {
-
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let type: InputValidation
         if textField == phonePrefixTextField {
@@ -134,19 +131,14 @@ extension AccountActivationController: UITextFieldDelegate {
 
         return validateTextChange(with: type, textField: textField, changeCharactersIn: range, newString: string)
     }
-
 }
 
 private extension AccountActivationController {
-
     func cleanup() {
         do {
             try Auth.auth().signOut()
-        } catch {
-
-        }
+        } catch {}
 
         UserDefaults.resetStandardUserDefaults()
     }
-
 }

--- a/BT-Tracking/Interface/Signup/BluetoothActivationController.swift
+++ b/BT-Tracking/Interface/Signup/BluetoothActivationController.swift
@@ -6,15 +6,14 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import UIKit
 import CoreBluetooth
+import UIKit
 import UserNotifications
 
 final class BluetoothActivationController: UIViewController, CBPeripheralManagerDelegate {
+    @IBOutlet private var scrollView: UIScrollView!
+    @IBOutlet private var buttonsView: ButtonsBackgroundView!
 
-    @IBOutlet private weak var scrollView: UIScrollView!
-    @IBOutlet private weak var buttonsView: ButtonsBackgroundView!
-    
     private var peripheralManager: CBPeripheralManager?
 
     private var bluetoothNotDetermined: Bool {
@@ -54,20 +53,18 @@ final class BluetoothActivationController: UIViewController, CBPeripheralManager
         NotificationCenter.default.removeObserver(
             self,
             name: UIApplication.didBecomeActiveNotification,
-            object: nil
-        )
+            object: nil)
     }
 
     // MARK: - Actions
-    
+
     @IBAction private func activateBluetoothAction() {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(applicationDidBecomeActive),
             name: UIApplication.didBecomeActiveNotification,
-            object: nil
-        )
-        
+            object: nil)
+
         checkForBluetooth()
     }
 
@@ -77,14 +74,10 @@ final class BluetoothActivationController: UIViewController, CBPeripheralManager
 
     // MARK: - CBPeripheralManagerDelegate
 
-    func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
-
-    }
-
+    func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {}
 }
 
 private extension BluetoothActivationController {
-
     func continueOnboarding() {
         UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
             DispatchQueue.main.async { [weak self] in
@@ -99,7 +92,7 @@ private extension BluetoothActivationController {
             }
         }
     }
-    
+
     func checkForBluetooth() {
         if bluetoothNotDetermined {
             requestBluetoothPermission()
@@ -119,17 +112,15 @@ private extension BluetoothActivationController {
             delegate: self,
             queue: nil,
             options: [
-                CBPeripheralManagerOptionShowPowerAlertKey: false,
-            ]
-        )
+                CBPeripheralManagerOptionShowPowerAlertKey: false
+            ])
     }
 
     func showBluetoothPermissionError() {
         showError(
             title: "Zapněte Bluetooth",
             message: "Bez zapnutého Bluetooth nemůžeme vytvářet seznam telefonů ve vašem okolí.",
-            okHandler: { [weak self] in self?.showAppSettings() }
-        )
+            okHandler: { [weak self] in self?.showAppSettings() })
     }
 
     func showAppSettings() {
@@ -137,5 +128,4 @@ private extension BluetoothActivationController {
         guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else { return }
         UIApplication.shared.open(settingsURL)
     }
-
 }

--- a/BT-Tracking/Interface/Signup/CompleteActivationController.swift
+++ b/BT-Tracking/Interface/Signup/CompleteActivationController.swift
@@ -6,14 +6,13 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import UIKit
-import RxSwift
-import RxRelay
-import FirebaseAuth
 import DeviceKit
+import FirebaseAuth
+import RxRelay
+import RxSwift
+import UIKit
 
 final class CompleteActivationController: UIViewController {
-
     var authData: AccountActivationController.AuthData?
 
     private var smsCode = BehaviorRelay<String>(value: "")
@@ -22,20 +21,21 @@ final class CompleteActivationController: UIViewController {
             InputValidation.smsCode.validate(phoneNumber)
         }
     }
+
     private var keyboardHandler: KeyboardHandler!
     private var disposeBag = DisposeBag()
 
     private var subtitle: String = ""
 
-    @IBOutlet private weak var scrollView: UIScrollView!
-    @IBOutlet private weak var buttonsView: ButtonsBackgroundView!
-    @IBOutlet private weak var buttonsBottomConstraint: NSLayoutConstraint!
+    @IBOutlet private var scrollView: UIScrollView!
+    @IBOutlet private var buttonsView: ButtonsBackgroundView!
+    @IBOutlet private var buttonsBottomConstraint: NSLayoutConstraint!
 
-    @IBOutlet private weak var titleLabel: UILabel!
-    @IBOutlet private weak var subtitleLabel: UILabel!
-    @IBOutlet private weak var smsCodeTextField: UITextField!
-    @IBOutlet private weak var actionButton: Button!
-    @IBOutlet private weak var activityView: UIView!
+    @IBOutlet private var titleLabel: UILabel!
+    @IBOutlet private var subtitleLabel: UILabel!
+    @IBOutlet private var smsCodeTextField: UITextField!
+    @IBOutlet private var actionButton: Button!
+    @IBOutlet private var activityView: UIView!
 
     private var expirationSeconds: TimeInterval = 0
     private var expirationTimer: Timer?
@@ -82,7 +82,7 @@ final class CompleteActivationController: UIViewController {
 
         let credential = PhoneAuthProvider.provider().credential(withVerificationID: authData.verificationID, verificationCode: smsCode.value)
 
-        Auth.auth().signIn(with: credential) { [weak self] authResult, error in
+        Auth.auth().signIn(with: credential) { [weak self] _, error in
             guard let self = self else { return }
 
             if let rawError = error {
@@ -103,8 +103,7 @@ final class CompleteActivationController: UIViewController {
                         },
                         action: (title: "Ne", handler: { [weak self] in
                             self?.smsCodeTextField.becomeFirstResponder()
-                        })
-                    )
+                        }))
                 } else {
                     self.show(error: error, title: "Chyba při aktivaci")
                     self.smsCodeTextField.becomeFirstResponder()
@@ -115,7 +114,7 @@ final class CompleteActivationController: UIViewController {
                     "platformVersion": UIDevice.current.systemVersion,
                     "manufacturer": "Apple",
                     "model": Device.current.description,
-                    "locale": "\(Locale.current.languageCode ?? "cs")_\(Locale.current.regionCode ?? "CZ")",
+                    "locale": "\(Locale.current.languageCode ?? "cs")_\(Locale.current.regionCode ?? "CZ")"
                 ]
 
                 if let token = AppDelegate.shared.deviceToken {
@@ -145,7 +144,6 @@ final class CompleteActivationController: UIViewController {
                             self.cleanup()
                         }
                     }
-
                 }
             }
         }
@@ -163,33 +161,29 @@ final class CompleteActivationController: UIViewController {
             if let error = error {
                 self.show(error: error, title: "Chyba při aktivaci")
                 self.cleanup()
-            } else if let verificationID = verificationID  {
+            } else if let verificationID = verificationID {
                 self.authData = AccountActivationController.AuthData(verificationID: verificationID, phoneNumber: phone)
                 self.startExpirationTimer()
                 self.smsCodeTextField.becomeFirstResponder()
             }
         }
     }
-
 }
 
 extension CompleteActivationController: UITextFieldDelegate {
-
     func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let type: InputValidation
         if textField == smsCodeTextField {
-             type = .smsCode
+            type = .smsCode
         } else {
-             return true
+            return true
         }
 
         return validateTextChange(with: type, textField: textField, changeCharactersIn: range, newString: string)
     }
-
 }
 
 private extension CompleteActivationController {
-
     func startExpirationTimer() {
         expirationSeconds = Date.timeIntervalSinceReferenceDate + RemoteValues.smsErrorTimeoutSeconds
         updateExpirationTitle()
@@ -204,8 +198,7 @@ private extension CompleteActivationController {
                     message: "Zkontrolujte telefonní číslo a nechte si odeslat nový ověřovací kód.",
                     okHandler: {
                         self.navigationController?.popViewController(animated: true)
-                    }
-                )
+                    })
                 return
             }
             self.updateExpirationTitle()
@@ -226,11 +219,8 @@ private extension CompleteActivationController {
     func cleanup() {
         do {
             try Auth.auth().signOut()
-        } catch {
-
-        }
+        } catch {}
 
         UserDefaults.resetStandardUserDefaults()
     }
-
 }

--- a/BT-Tracking/Interface/Signup/FirstActivationController.swift
+++ b/BT-Tracking/Interface/Signup/FirstActivationController.swift
@@ -6,14 +6,13 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import UIKit
 import CoreBluetooth
+import UIKit
 import UserNotifications
 
 final class FirstActivationController: UIViewController {
-
-    @IBOutlet private weak var scrollView: UIScrollView!
-    @IBOutlet private weak var buttonsView: ButtonsBackgroundView!
+    @IBOutlet private var scrollView: UIScrollView!
+    @IBOutlet private var buttonsView: ButtonsBackgroundView!
 
     // MARK: -
 
@@ -24,7 +23,7 @@ final class FirstActivationController: UIViewController {
     }
 
     // MARK: - Actions
-    
+
     @IBAction private func continueAction() {
         if bluetoothAuthorized {
             UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
@@ -42,17 +41,16 @@ final class FirstActivationController: UIViewController {
             performSegue(withIdentifier: "bluetooth", sender: nil)
         }
     }
-    
+
     @IBAction private func auditsURLAction(_ sender: Any) {
         guard let url = URL(string: RemoteValues.proclamationLink) else { return }
         openURL(URL: url)
     }
-    
+
     private var bluetoothAuthorized: Bool {
         if #available(iOS 13.0, *) {
             return CBCentralManager().authorization == .allowedAlways
         }
         return CBPeripheralManager.authorizationStatus() == .authorized
     }
-
 }

--- a/BT-Tracking/Interface/Signup/NotificationPermissionController.swift
+++ b/BT-Tracking/Interface/Signup/NotificationPermissionController.swift
@@ -10,9 +10,8 @@ import UIKit
 import UserNotifications
 
 final class NotificationPermissionController: UIViewController {
-
-    @IBOutlet private weak var scrollView: UIScrollView!
-    @IBOutlet private weak var buttonsView: ButtonsBackgroundView!
+    @IBOutlet private var scrollView: UIScrollView!
+    @IBOutlet private var buttonsView: ButtonsBackgroundView!
 
     // MARK: -
 
@@ -23,13 +22,13 @@ final class NotificationPermissionController: UIViewController {
     }
 
     // MARK: - Action
-    
+
     @IBAction func continueAction(_ sender: Any) {
         requestPermission()
     }
-    
+
     // MARK: - Request permission
-    
+
     private func requestPermission() {
         let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
         UNUserNotificationCenter.current().requestAuthorization(

--- a/BT-Tracking/Interface/Unregister User/UnregisterFinishVC.swift
+++ b/BT-Tracking/Interface/Unregister User/UnregisterFinishVC.swift
@@ -9,9 +9,8 @@
 import UIKit
 
 final class UnregisterFinishVC: UIViewController {
-
-    @IBOutlet private weak var titleLabel: UILabel!
-    @IBOutlet private weak var closeButton: RoundedButtonFilled!
+    @IBOutlet private var titleLabel: UILabel!
+    @IBOutlet private var closeButton: RoundedButtonFilled!
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/BT-Tracking/Interface/Unregister User/UnregisterUserVC.swift
+++ b/BT-Tracking/Interface/Unregister User/UnregisterUserVC.swift
@@ -6,13 +6,12 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import UIKit
 import FirebaseAuth
+import UIKit
 
 final class UnregisterUserVC: UIViewController {
-
-    @IBOutlet private weak var activityView: UIView!
-    @IBOutlet private weak var textLabel: UILabel!
+    @IBOutlet private var activityView: UIView!
+    @IBOutlet private var textLabel: UILabel!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -24,8 +23,8 @@ final class UnregisterUserVC: UIViewController {
 
     @IBAction private func unregisterAction() {
         activityView.isHidden = false
-        
-        AppDelegate.shared.functions.httpsCallable("deleteUser").call() { [weak self] result, error in
+
+        AppDelegate.shared.functions.httpsCallable("deleteUser").call { [weak self] _, error in
             guard let self = self else { return }
             self.activityView.isHidden = true
 

--- a/BT-Tracking/Services/AppSettings.swift
+++ b/BT-Tracking/Services/AppSettings.swift
@@ -9,16 +9,15 @@
 import Foundation
 
 struct AppSettings {
-
     static let firebaseRegion = "europe-west1"
     static let backgroundModeAlertShownKey = "backgroundModeAlertShown"
     static let appFirstTimeLaunchedKey = "appFirstTimeLaunched"
-    
+
     static let TUIDRotation: Int = 60 * 60
 
     static var state: ActiveAppViewModel.State? {
         get {
-            return ActiveAppViewModel.State(rawValue: UserDefaults.standard.string(forKey: "AppState") ?? "")
+            ActiveAppViewModel.State(rawValue: UserDefaults.standard.string(forKey: "AppState") ?? "")
         }
         set {
             UserDefaults.standard.setValue(newValue?.rawValue, forKey: "AppState")
@@ -35,19 +34,19 @@ struct AppSettings {
             UserDefaults.standard.set(newValue?.timeIntervalSince1970, forKey: "UploadDate")
         }
     }
-    
+
     static var backgroundModeAlertShown: Bool {
         get {
-            return UserDefaults.standard.bool(forKey: backgroundModeAlertShownKey)
+            UserDefaults.standard.bool(forKey: backgroundModeAlertShownKey)
         }
         set {
             UserDefaults.standard.set(newValue, forKey: backgroundModeAlertShownKey)
         }
     }
-    
+
     static var appFirstTimeLaunched: Bool {
         get {
-            return UserDefaults.standard.bool(forKey: appFirstTimeLaunchedKey)
+            UserDefaults.standard.bool(forKey: appFirstTimeLaunchedKey)
         }
         set {
             UserDefaults.standard.set(newValue, forKey: appFirstTimeLaunchedKey)
@@ -57,7 +56,7 @@ struct AppSettings {
     static func deleteAllData() {
         KeychainService.BUID = nil
         KeychainService.TUIDs = nil
-        
+
         AppSettings.state = nil
         AppSettings.lastUploadDate = nil
         AppSettings.backgroundModeAlertShown = false

--- a/BT-Tracking/Services/Bluetooth/BT.swift
+++ b/BT-Tracking/Services/Bluetooth/BT.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
-import UIKit
 import CoreBluetooth
+import UIKit
 
 enum BT: String {
     case advertiserName = "Covid-19"

--- a/BT-Tracking/Services/Bluetooth/BTDevice.swift
+++ b/BT-Tracking/Services/Bluetooth/BTDevice.swift
@@ -33,9 +33,9 @@ struct BTDevice {
          medianRssi: Int? = nil) {
         self.id = id
         if platform == .android {
-            self.deviceIdentifier = backendIdentifier ?? bluetoothIdentifier.uuidString
+            deviceIdentifier = backendIdentifier ?? bluetoothIdentifier.uuidString
         } else {
-            self.deviceIdentifier = bluetoothIdentifier.uuidString
+            deviceIdentifier = bluetoothIdentifier.uuidString
         }
         self.bluetoothIdentifier = bluetoothIdentifier
         self.backendIdentifier = backendIdentifier
@@ -45,24 +45,23 @@ struct BTDevice {
         self.rssi = rssi
         self.medianRssi = medianRssi
     }
-    
+
     func toScan(with uuid: String? = nil) -> Scan {
         Scan(
             id: uuid ?? UUID().uuidString,
-            bluetoothIdentifier: self.bluetoothIdentifier.uuidString,
-            deviceIdentifier: self.deviceIdentifier,
-            buid: self.backendIdentifier ?? "unknown",
-            platform: self.platform,
-            name: self.name ?? self.platform.rawValue,
-            date: self.date,
-            rssi: self.rssi,
-            medianRssi: self.medianRssi
-        )
-    }    
+            bluetoothIdentifier: bluetoothIdentifier.uuidString,
+            deviceIdentifier: deviceIdentifier,
+            buid: backendIdentifier ?? "unknown",
+            platform: platform,
+            name: name ?? platform.rawValue,
+            date: date,
+            rssi: rssi,
+            medianRssi: medianRssi)
+    }
 }
 
 extension BTDevice: Equatable {
-    static func == (lhs: Self, rhs: Self) -> Bool {
-        return lhs.backendIdentifier == rhs.backendIdentifier
+    static func ==(lhs: Self, rhs: Self) -> Bool {
+        lhs.backendIdentifier == rhs.backendIdentifier
     }
 }

--- a/BT-Tracking/Services/CSV/CSVWriter.swift
+++ b/BT-Tracking/Services/CSV/CSVWriter.swift
@@ -6,12 +6,11 @@
 //  Copyright © 2020 Covid19CZ. All rights reserved.
 //
 
+import CSV
 import Foundation
 import RealmSwift
-import CSV
 
 protocol CSVMakering {
-
     typealias Result = (fileURL: URL, metadata: [String: String])
     typealias Callback = (_ result: Result?, _ error: Error?) -> Void
 
@@ -22,19 +21,18 @@ protocol CSVMakering {
 }
 
 /*
-buid,timestampStart,timestampEnd,minRssi,maxRssi,avgRssi,medRssi
-b5e446a423330ca0e143,1584896543951,1584896587921,0,-38,0,-63
-b5e446a423330ca0e143,1584896663553,1584896686886,0,-63,0,-68
-b5e446a423330ca0e143,1584897450231,1584897452256,0,-74,0,-75
-*/
+ buid,timestampStart,timestampEnd,minRssi,maxRssi,avgRssi,medRssi
+ b5e446a423330ca0e143,1584896543951,1584896587921,0,-38,0,-63
+ b5e446a423330ca0e143,1584896663553,1584896686886,0,-63,0,-68
+ b5e446a423330ca0e143,1584897450231,1584897452256,0,-74,0,-75
+ */
 
 final class CSVMaker: CSVMakering {
-
     private(set) var fileURL: URL
     private(set) var fromDate: Date?
 
     init?(fromDate: Date?) {
-        self.fileURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("db.csv")
+        fileURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("db.csv")
         self.fromDate = fromDate
     }
 
@@ -49,7 +47,7 @@ final class CSVMaker: CSVMakering {
         do {
             csv = try CSVWriter(stream: stream)
             try csv.write(row: ["tuid", "timestampStart", "timestampEnd", "avgRssi", "medRssi"])
-            
+
             realm = try Realm()
         } catch {
             callback(nil, error)
@@ -61,7 +59,7 @@ final class CSVMaker: CSVMakering {
             data = data.filter("startDate >= %@", fromDate)
         }
 
-        data.forEach() { scan in
+        data.forEach { scan in
             try? csv.write(row: [
                 scan.buid,
                 String(scan.startDate.timeIntervalSince1970),

--- a/BT-Tracking/Services/KeychainService.swift
+++ b/BT-Tracking/Services/KeychainService.swift
@@ -11,10 +11,9 @@ import Security
 import UIKit
 
 struct KeychainService {
-
     static var BUID: String? {
         get {
-            return stringValue(for: .BUID)
+            stringValue(for: .BUID)
         }
         set {
             if let value = newValue {
@@ -27,7 +26,7 @@ struct KeychainService {
 
     static var TUIDs: [String]? {
         get {
-            return arrayValue(for: .TUIDs)
+            arrayValue(for: .TUIDs)
         }
         set {
             if let values = newValue {
@@ -41,7 +40,6 @@ struct KeychainService {
 }
 
 private extension KeychainService {
-
     enum Keys: String {
         case BUID
         case TUIDs
@@ -78,10 +76,9 @@ private extension KeychainService {
         }
 
         static func dictionaryFrom(_ values: [Self: Any]) -> NSDictionary {
-            return NSDictionary(
+            NSDictionary(
                 objects: Array(values.values),
-                forKeys: values.keys.map { $0.rawValue } as [NSString]
-            ) as CFDictionary
+                forKeys: values.keys.map { $0.rawValue } as [NSString]) as CFDictionary
         }
     }
 

--- a/BT-Tracking/Services/Logger/FileLogger.swift
+++ b/BT-Tracking/Services/Logger/FileLogger.swift
@@ -9,16 +9,15 @@
 import Foundation
 
 final class FileLogger {
-    
     static let shared = FileLogger()!
 
     private(set) var fileURL: URL
-    
+
     init?() {
         guard let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first else { return nil }
-        self.fileURL = URL(fileURLWithPath: documents).appendingPathComponent("application.log")
+        fileURL = URL(fileURLWithPath: documents).appendingPathComponent("application.log")
     }
-    
+
     func writeLog(_ text: String) {
         do {
             let newText = getLog() + "\n" + formatter.string(from: Date()) + " " + text
@@ -27,7 +26,7 @@ final class FileLogger {
             print("Unexpected error writing to log: \(error)")
         }
     }
-    
+
     func getLog() -> String {
         do {
             return try String(contentsOf: fileURL, encoding: .utf8)
@@ -36,7 +35,7 @@ final class FileLogger {
             return ""
         }
     }
-    
+
     func purgeLogs() {
         do {
             try "".write(to: fileURL, atomically: false, encoding: .utf8)

--- a/BT-Tracking/Services/Logger/Logger.swift
+++ b/BT-Tracking/Services/Logger/Logger.swift
@@ -15,7 +15,7 @@ func log(_ text: String) {
     }
 }
 
-protocol LogDelegate: class {
+protocol LogDelegate: AnyObject {
     func didLog(_ text: String)
 }
 
@@ -27,4 +27,3 @@ struct Log {
         print(text)
     }
 }
-

--- a/BT-Tracking/Services/RemoteValues.swift
+++ b/BT-Tracking/Services/RemoteValues.swift
@@ -12,7 +12,6 @@ import FirebaseRemoteConfig
 #endif
 
 extension AppDelegate {
-
     func setupFirebaseRemoteConfig() {
         setupDefaultValues()
         fetchRemoteValues()
@@ -45,17 +44,16 @@ extension AppDelegate {
     }
 
     func remoteConfigValue(forKey key: RemoteConfigValueKey) -> Any {
-        return RemoteConfig.remoteConfig()[key.rawValue]
+        RemoteConfig.remoteConfig()[key.rawValue]
     }
 
     func remoteConfigInt(forKey key: RemoteConfigValueKey) -> Int {
-        return RemoteConfig.remoteConfig()[key.rawValue].numberValue?.intValue ?? 0
+        RemoteConfig.remoteConfig()[key.rawValue].numberValue?.intValue ?? 0
     }
 
     func remoteConfigString(forKey key: RemoteConfigValueKey) -> String {
-        return RemoteConfig.remoteConfig()[key.rawValue].stringValue ?? ""
+        RemoteConfig.remoteConfig()[key.rawValue].stringValue ?? ""
     }
-
 }
 
 enum RemoteConfigValueKey: String {
@@ -76,13 +74,12 @@ enum RemoteConfigValueKey: String {
     case shareAppDynamicLink
 
     case emergencyNumber
-    
+
     case helpMarkdown
     case dataCollectionMarkdown
 }
 
 struct RemoteValues {
-
     static let defaults: [RemoteConfigValueKey: Any?] = [
         .collectionSeconds: 120,
         .waitingSeconds: 0,
@@ -101,7 +98,7 @@ struct RemoteValues {
         .shareAppDynamicLink: "https://covid19cz.page.link/share",
 
         .emergencyNumber: 1212,
-        
+
         .helpMarkdown: helpMarkdownBackup,
         .dataCollectionMarkdown: dataCollectionMarkdownBackup
     ]
@@ -117,93 +114,93 @@ struct RemoteValues {
     }
 
     private static var helpMarkdownBackup: String {
-        return localValue(forResource: "MarkdownBackups", withExtension: "strings", withKey: "helpMarkdownBackup")
+        localValue(forResource: "MarkdownBackups", withExtension: "strings", withKey: "helpMarkdownBackup")
     }
 
     private static var dataCollectionMarkdownBackup: String {
-        return localValue(forResource: "MarkdownBackups", withExtension: "strings", withKey: "dataCollectionInfoBackup")
+        localValue(forResource: "MarkdownBackups", withExtension: "strings", withKey: "dataCollectionInfoBackup")
     }
 
     /// doba scanování v sekundách, default = 120
     static var collectionSeconds: Int {
-        return AppDelegate.shared.remoteConfigInt(forKey: RemoteConfigValueKey.collectionSeconds)
+        AppDelegate.shared.remoteConfigInt(forKey: RemoteConfigValueKey.collectionSeconds)
     }
 
     /// doba čekání mezi scany, default = 0
     static var waitingSeconds: Int {
-        return AppDelegate.shared.remoteConfigInt(forKey: RemoteConfigValueKey.waitingSeconds)
+        AppDelegate.shared.remoteConfigInt(forKey: RemoteConfigValueKey.waitingSeconds)
     }
 
     /// pro in-app statistiky, úroveň rssi kdy je kontakt nebezpečný, číslo, default = -75
     static var criticalExpositionRssi: Int {
-        return AppDelegate.shared.remoteConfigInt(forKey: RemoteConfigValueKey.criticalExpositionRssi)
+        AppDelegate.shared.remoteConfigInt(forKey: RemoteConfigValueKey.criticalExpositionRssi)
     }
 
     /// timeout na automatické ověření SMS, default = 20
     static var smsErrorTimeoutSeconds: TimeInterval {
-        return TimeInterval(AppDelegate.shared.remoteConfigInt(forKey: RemoteConfigValueKey.smsErrorTimeoutSeconds))
+        TimeInterval(AppDelegate.shared.remoteConfigInt(forKey: RemoteConfigValueKey.smsErrorTimeoutSeconds))
     }
 
     /// doba mezi uploady, v minutách, číslo, default = 15min
     static var uploadWaitingMinutes: TimeInterval {
-        return TimeInterval(AppDelegate.shared.remoteConfigInt(forKey: RemoteConfigValueKey.uploadWaitingMinutes) * 60 * 60)
+        TimeInterval(AppDelegate.shared.remoteConfigInt(forKey: RemoteConfigValueKey.uploadWaitingMinutes) * 60 * 60)
     }
-    
+
     /// počet dní, jak dlouho se mají držet data v telefonu ve dnech, default = 14
     static var persistDataDays: Int {
-        return AppDelegate.shared.remoteConfigInt(forKey: RemoteConfigValueKey.persistDataDays)
+        AppDelegate.shared.remoteConfigInt(forKey: RemoteConfigValueKey.persistDataDays)
     }
-    
+
     static var persistDataInterval: TimeInterval {
-        return TimeInterval(persistDataDays * 60 * 60 * 24)
+        TimeInterval(persistDataDays * 60 * 60 * 24)
     }
-    
+
     /// odkaz na FAQ - vede z obrazovky Kontakty
     static var faqLink: String {
-        return AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.faqLink)
+        AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.faqLink)
     }
 
     /// odkaz na důležité kontakty - vede z obrazovky Kontakty
     static var importantLink: String {
-        return AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.importantLink)
+        AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.importantLink)
     }
 
     /// odkaz na prohlášení o podpoře - vede z úvodní obrazovky a z nápovědy
     static var proclamationLink: String {
-        return AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.proclamationLink)
+        AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.proclamationLink)
     }
 
     /// Podminky zpracovan
     static var termsAndConditionsLink: String {
-        return AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.termsAndConditionsLink)
+        AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.termsAndConditionsLink)
     }
 
     /// Odkaz na tým - erouska.cz/tym
     static var aboutLink: String {
-        return AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.aboutLink)
+        AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.aboutLink)
     }
 
     /// Homepage - erouska.cz
     static var homepageLink: String {
-        return AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.homepageLink)
+        AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.homepageLink)
     }
 
     static var shareAppDynamicLink: String {
-        return AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.shareAppDynamicLink).trimmingCharacters(in: .whitespacesAndNewlines)
+        AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.shareAppDynamicLink).trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     /// nouzové číslo - 1212
     static var emergencyPhonenumber: Int {
-        return AppDelegate.shared.remoteConfigInt(forKey: RemoteConfigValueKey.emergencyNumber)
+        AppDelegate.shared.remoteConfigInt(forKey: RemoteConfigValueKey.emergencyNumber)
     }
 
     /// Help markdown
     static var helpMarkdown: String {
-        return AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.helpMarkdown)
+        AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.helpMarkdown)
     }
 
     /// Data collection markdown
     static var dataCollectionMarkdown: String {
-        return AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.dataCollectionMarkdown)
+        AppDelegate.shared.remoteConfigString(forKey: RemoteConfigValueKey.dataCollectionMarkdown)
     }
 }

--- a/BT-Tracking/Services/Store/Scan.swift
+++ b/BT-Tracking/Services/Store/Scan.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct Scan: Equatable {
     let id: String
-    
+
     let bluetoothIdentifier: String
     let deviceIdentifier: String
     let buid: String

--- a/BT-Tracking/Services/Store/ScanRealm.swift
+++ b/BT-Tracking/Services/Store/ScanRealm.swift
@@ -10,7 +10,6 @@ import Foundation
 import RealmSwift
 
 final class ScanRealm: Object {
-    
     @objc dynamic var id = ""
     @objc dynamic var bluetoothIdentifier = ""
     @objc dynamic var deviceIdentifier = ""
@@ -21,49 +20,47 @@ final class ScanRealm: Object {
     @objc dynamic var endDate = Date()
     @objc dynamic var avargeRssi = 0
     @objc dynamic var medianRssi = 0
-    
+
     var platform: BTDevice.Platform? {
         get {
-            BTDevice.Platform.init(rawValue: _platform)
+            BTDevice.Platform(rawValue: _platform)
         }
         set {
             guard let platform = newValue else { return }
             _platform = platform.rawValue
         }
     }
-    
+
     override class func primaryKey() -> String {
-        return "id"
+        "id"
     }
-    
+
     convenience init(device: BTDevice, avargeRssi: Int, medianRssi: Int, startDate: Date, endDate: Date) {
         self.init()
-        
-        self.id = UUID().uuidString
-        self.bluetoothIdentifier = device.bluetoothIdentifier.uuidString
-        self.deviceIdentifier = device.deviceIdentifier
-        self.buid = device.backendIdentifier ?? ""
-        self.platform = device.platform
-        self.name = device.name
+
+        id = UUID().uuidString
+        bluetoothIdentifier = device.bluetoothIdentifier.uuidString
+        deviceIdentifier = device.deviceIdentifier
+        buid = device.backendIdentifier ?? ""
+        platform = device.platform
+        name = device.name
 
         self.startDate = startDate
         self.endDate = endDate
         self.avargeRssi = avargeRssi
         self.medianRssi = medianRssi
     }
-    
+
     func toScan() -> Scan {
         Scan(
-            id: self.id,
-            bluetoothIdentifier: self.bluetoothIdentifier,
-            deviceIdentifier: self.deviceIdentifier,
-            buid: self.buid,
-            platform: self.platform ?? .iOS, // Adding defuault `.iOS` rather then failing whole mapping
-            name: self.name ?? "neznámé",
-            date: self.startDate,
-            rssi: self.avargeRssi,
-            medianRssi: self.medianRssi
-        )
+            id: id,
+            bluetoothIdentifier: bluetoothIdentifier,
+            deviceIdentifier: deviceIdentifier,
+            buid: buid,
+            platform: platform ?? .iOS, // Adding defuault `.iOS` rather then failing whole mapping
+            name: name ?? "neznámé",
+            date: startDate,
+            rssi: avargeRssi,
+            medianRssi: medianRssi)
     }
-    
 }


### PR DESCRIPTION
- Added `.swiftformat` file with a set of rules to be enforced
- Formatted code

The tool can be found [here](https://github.com/nicklockwood/SwiftFormat), list of all available rules [here](https://github.com/nicklockwood/SwiftFormat/blob/master/Rules.md).

To format code, one simply calls `swiftformat .` from the project's directory. 

This can be either set-up to be run on a CI server in the future, or as a build phase script. 

Feedback appreciated.