### PR TITLE
Unregister user even with an error

### DIFF
--- a/BT-Tracking/Interface/Unregister User/UnregisterUserVC.swift
+++ b/BT-Tracking/Interface/Unregister User/UnregisterUserVC.swift
@@ -41,7 +41,8 @@ final class UnregisterUserVC: UIViewController {
             guard let self = self else { return }
             self.hideProgress()
 
-            if let error = error as NSError? {
+            if let error = error as NSError?,
+                error.code != AuthErrorCode.userNotFound.rawValue {
                 Log.log("deleteUser request failed with error: \(error.localizedDescription)")
                 self.show(error: error, title: self.viewModel.errorTitle)
                 return


### PR DESCRIPTION
Is there a reason not to let the user unregister if there's been an error in the unregister request? If not, then this is a fix to the following.

Steps to reproduce
- Register on a device A
- Register on a device B using the same number
- Unregister on A
- Try to unregister on B - an error alert shown, nothing happens
- Now the on device B can't ever get unregistered