### PR TITLE
Fix a translation

### DIFF
--- a/BT-Tracking/Interface/Signup/AccountActivationVC.swift
+++ b/BT-Tracking/Interface/Signup/AccountActivationVC.swift
@@ -165,8 +165,8 @@ private extension AccountActivationVC {
         log("Auth: verifyPhoneNumber error: \(error.localizedDescription)")
         if (error as NSError).code == AuthErrorCode.tooManyRequests.rawValue {
             showAlert(
-                title: viewModel.errorToManyRequestsTitle,
-                message: viewModel.errorToManyRequestsMessage
+                title: viewModel.errorTooManyRequestsTitle,
+                message: viewModel.errorTooManyRequestsMessage
             )
         } else {
             showAlert(

--- a/BT-Tracking/Interface/Signup/AccountActivationVM.swift
+++ b/BT-Tracking/Interface/Signup/AccountActivationVM.swift
@@ -32,9 +32,9 @@ struct AccountActivationVM {
 
     let continueButton = "login_continue"
 
-    let errorToManyRequestsTitle = "login_error_too_many_requests_title"
+    let errorTooManyRequestsTitle = "login_error_too_many_requests_title"
 
-    let errorToManyRequestsMessage = "login_error_too_many_requests_message"
+    let errorTooManyRequestsMessage = "login_error_too_many_requests_message"
 
     let errorVerificationTitle = "login_error_verification_title"
 

--- a/BT-Tracking/Resources/Base.lproj/Localizable.strings
+++ b/BT-Tracking/Resources/Base.lproj/Localizable.strings
@@ -34,7 +34,7 @@
 "login_continue" = "Pokračovat";
 "login_error_too_many_requests_title" = "Telefonní číslo jsme dočasně zablokovali";
 "login_error_too_many_requests_message" = "Několikrát jste zkusili neúspěšně ověřit telefonní číslo. Za chvíli to zkuste znovu.";
-"login_error_verification_title" = "Telefonní číslo jsme dočasně zablokovali";
+"login_error_verification_title" = "Nepodařilo se nám ověřit telefonní číslo";
 "login_error_verification_message" = "Zkontrolujte připojení k internetu a zkuste to znovu.";
 
 "login_code_title" = "Ověřovací kód";

--- a/BT-Tracking/Resources/cs.lproj/Localizable.strings
+++ b/BT-Tracking/Resources/cs.lproj/Localizable.strings
@@ -34,7 +34,7 @@
 "login_continue" = "Pokračovat";
 "login_error_too_many_requests_title" = "Telefonní číslo jsme dočasně zablokovali";
 "login_error_too_many_requests_message" = "Několikrát jste zkusili neúspěšně ověřit telefonní číslo. Za chvíli to zkuste znovu.";
-"login_error_verification_title" = "Telefonní číslo jsme dočasně zablokovali";
+"login_error_verification_title" = "Nepodařilo se nám ověřit telefonní číslo";
 "login_error_verification_message" = "Zkontrolujte připojení k internetu a zkuste to znovu.";
 
 "login_code_title" = "Ověřovací kód";

--- a/BT-Tracking/Resources/en.lproj/Localizable.strings
+++ b/BT-Tracking/Resources/en.lproj/Localizable.strings
@@ -34,7 +34,7 @@
 "login_continue" = "Pokračovat";
 "login_error_too_many_requests_title" = "Telefonní číslo jsme dočasně zablokovali";
 "login_error_too_many_requests_message" = "Několikrát jste zkusili neúspěšně ověřit telefonní číslo. Za chvíli to zkuste znovu.";
-"login_error_verification_title" = "Telefonní číslo jsme dočasně zablokovali";
+"login_error_verification_title" = "Nepodařilo se nám ověřit telefonní číslo";
 "login_error_verification_message" = "Zkontrolujte připojení k internetu a zkuste to znovu.";
 
 "login_code_title" = "Ověřovací kód";


### PR DESCRIPTION
Changed the title for a general phone error from `Telefonní číslo jsme dočasně zablokovali` to `Nepodařilo se nám ověřit telefonní číslo`.