### PR TITLE
Struktura README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,50 @@
-# erouska-ios
+![# eRouška](https://erouska.cz/img/logo.svg)
 
-Test account: 604 123456, code: 123456
+![Platform: iOS](https://img.shields.io/badge/platform-ios-brightgreen)
+
+[![Download on the App Store](https://developer.apple.com/app-store/marketing/guidelines/images/badge-download-on-the-app-store.svg)](https://apps.apple.com/cz/app/erouška/id1509210215)
+
+Read our **FAQ**: [Czech](https://erouska.cz/caste-dotazy), [English](https://erouska.cz/en/caste-dotazy)
+
+eRouška (_rouška_ = _face mask_ in Czech) helps to fight against COVID-19.
+
+eRouška uses Bluetooth to scan the area around the device for other eRouška users and saves the data of these encounters.
+
+It's the only app in Czechia authorized to use Exposure Notifications API from Apple/Google.
+
+## Who is developing eRouška?
+
+Starting with version 2.0, the eRouška application is developed by the Ministry of Health in collaboration with the National Agency for Communication and Information Technologies ([NAKIT](https://nakit.cz/)). Earlier versions of eRouška application were developed by a team of volunteers from the [COVID19CZ](https://covid19cz.cz) community. Most of original eRouška developers continue to work on newer versions in the NAKIT team.
+
+## International cooperation
+
+We are open-source from day one and we will be happy to work with people in other countries if they want to develop a similar app. Contact [David Vávra](mailto:david.vavra@erouska.cz) for technical details.
+
+## Building the App from the source code
+
+Exposure notifications work only with approved Ministry account.
+
+You can build using your own account when you delete `com.apple.developer.exposure-notification` entitlement from `BT-Tracking.entitlements` file and change code signing to your account.
+
+### Dependencies
+
+Most dependencies are installed using Swift package manager and will download using Xcode. Only Firebase dependencies do not yet support SPM and must be installed using CocoaPods (`pod install`).
+
+### Test account
+
+- Phone: +420 604 123 456
+- Code: 123456
+
+## Contributing
+We are happy to accept pull requests! See [Git Workflow](#user-content-git-workflow).
+
+If you want to become a more permanent part of the team, join [our Slack](https://covid19cz.slack.com), channel _#erouska_.
+
+## Translations
+
+Help us translate to your language or if you see a problem with translation, fix it. Our translation is open to volunteers [at OneSky](https://covid19cz.oneskyapp.com/).
+
+## Git workflow
+
+- Work in a fork then send a pull request to the `develop` branch. 
+- Releases are tagged.

--- a/README.md
+++ b/README.md
@@ -30,11 +30,6 @@ You can build using your own account when you delete `com.apple.developer.exposu
 
 Most dependencies are installed using Swift package manager and will download using Xcode. Only Firebase dependencies do not yet support SPM and must be installed using CocoaPods (`pod install`).
 
-### Test account
-
-- Phone: +420 604 123 456
-- Code: 123456
-
 ## Contributing
 We are happy to accept pull requests! See [Git Workflow](#user-content-git-workflow).
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ We are open-source from day one and we will be happy to work with people in othe
 
 Exposure notifications work only with approved Ministry account.
 
-You can build using your own account when you delete `com.apple.developer.exposure-notification` entitlement from `BT-Tracking.entitlements` file and change code signing to your account.
+You can build using your own account when you delete `com.apple.developer.exposure-notification` entitlement from `BT-Tracking-Debug.entitlements` file and change code signing to your account.
 
 ### Dependencies
 


### PR DESCRIPTION
Dobrý den,  
procházel jsem si repozitář a narazil jsem na chybějící README, které by určitě minimálně ve vývojářské komunitě mohlo lehce zvednout důvěryhodnost projektu. A pak jsem si všiml, že tento úkol už v projektu máte:

https://github.com/covid19cz/erouska-ios/projects/2#card-42668724

Zhostil jsem se toho a vykopnul nějakou prvotní verzi, která silně vychází z README pro Android. Vykreselené README lze vidět například zde:

https://github.com/mkj-is/erouska-ios/blob/feature/readme/README.md

Pár dalších kroků:

- Pokud chcete, aby PR byly automaticky směrované do `develop`, bylo by ji dobré nastavit jako hlavní větev.
- Na odkazu na Slack se nedá registrovat, ani přes formulář jsem za několik měsíců nedostal pozvánku. Tím pádem ani vážnější zájemci o spolupráci nemají jasnou metodu jak se přidat.
- Dokumentaci by z mého pohledu určitě stálo za to postupně rozšiřovat, projekt používá hodně závislostí a architektonická rozhodnutí za nimi nejsou transparentní.

Každopádně díky za nepolevující práci!